### PR TITLE
Update to RPA Framework 27

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
-# Google image search example robot using Firefox browser
+# Google image search example using Firefox browser
 
-Executes Google image search and stores the first result image using Firerfox browser and webdriver that are loaded from conda-forge.
+Executes Google image search and stores the first result image using the Firerfox
+browser downloaded from Conda Forge. (the right webdriver is automatically handled by
+the library itself)
 
-Execution is done in fully headless mode so browser will not even be visible and this robot is executable on the Robocorp hosted Cloud Containers as is.
+Execution is done in fully headless mode so the browser will not even be visible, this
+way the robot is runnable in Robocorp's Control Room (Cloud Container) as it is.

--- a/conda.yaml
+++ b/conda.yaml
@@ -1,19 +1,14 @@
+# For more details on the format and content:
+# https://github.com/robocorp/rcc/blob/master/docs/recipes.md#what-is-in-condayaml
+# Tip: Adding a link to the release notes of the packages helps maintenance and security.
+
 channels:
-  # Define conda channels here.
   - conda-forge
 
 dependencies:
-  # Define conda packages here.
-  # If available, always prefer the conda version of a package.
-  # Installation will be faster and more efficient.
-  # https://anaconda.org/search
-  - python=3.9.16            # https://pyreadiness.org/3.9/ 
-
-  # Load Firefox from conda-forge.
-  - firefox=117.0            # https://anaconda.org/conda-forge/firefox
-  - geckodriver=0.33.0       # https://anaconda.org/conda-forge/geckodriver
-  - pip=22.3.1               # https://pip.pypa.io/en/stable/news/
+  - python=3.10.12                    # https://pyreadiness.org/3.10
+  - robocorp-truststore=0.8.0         # https://pypi.org/project/robocorp-truststore/
+  - firefox=119
+  - pip=23.2.1                        # https://pip.pypa.io/en/stable/news
   - pip:
-      # Define pip packages here.
-      # https://pypi.org/
-      - rpaframework==26.1.0 # https://rpaframework.org/releasenotes.html
+    - rpaframework==27.5.0            # https://rpaframework.org/releasenotes.html

--- a/conda.yaml
+++ b/conda.yaml
@@ -8,7 +8,9 @@ channels:
 dependencies:
   - python=3.10.12                    # https://pyreadiness.org/3.10
   - robocorp-truststore=0.8.0         # https://pypi.org/project/robocorp-truststore/
-  - firefox=119
+  - firefox=119                       # https://prefix.dev/channels/conda-forge/packages/firefox
+  # Uncomment if you want to pin a specific webdriver version.
+  # - geckodriver=0.33.0              # https://prefix.dev/channels/conda-forge/packages/geckodriver
   - pip=23.2.1                        # https://pip.pypa.io/en/stable/news
   - pip:
     - rpaframework==27.5.0            # https://rpaframework.org/releasenotes.html

--- a/robot.yaml
+++ b/robot.yaml
@@ -4,8 +4,6 @@
 tasks:
   Image search with Firefox:
     robotTaskName: Execute Google image search and store the first result image
-  Debug image search with Firefox:
-    shell: python -m robot -L TRACE --outputdir output --logtitle "Task log" tasks.robot
 
 environmentConfigs:
   - environment_windows_amd64_freeze.yaml

--- a/robot.yaml
+++ b/robot.yaml
@@ -1,22 +1,23 @@
-tasks:
-  Image search:
-    command:
-      - python
-      - -m
-      - robot
-      - --report
-      - NONE
-      - -d
-      - output
-      - --logtitle
-      - Task log
-      - tasks.robot
+# For more details on the format and content:
+# https://github.com/robocorp/rcc/blob/master/docs/recipes.md#what-is-in-robotyaml
 
-condaConfigFile: conda.yaml
+tasks:
+  Image search with Firefox:
+    robotTaskName: Execute Google image search and store the first result image
+  Debug image search with Firefox:
+    shell: python -m robot -L TRACE --outputdir output --logtitle "Task log" tasks.robot
+
+environmentConfigs:
+  - environment_windows_amd64_freeze.yaml
+  - environment_linux_amd64_freeze.yaml
+  - environment_darwin_amd64_freeze.yaml
+  - conda.yaml
+
 artifactsDir: output
-ignoreFiles:
-  - .gitignore
+
 PATH:
   - .
 PYTHONPATH:
   - .
+ignoreFiles:
+  - .gitignore

--- a/tasks.robot
+++ b/tasks.robot
@@ -1,10 +1,13 @@
 *** Settings ***
 Documentation     Executes Google image search and stores the first result image.
+
 Library           RPA.Browser.Selenium
+
 
 *** Variables ***
 ${GOOGLE_URL}     https://google.com/?hl=en
-${SEARCH_TERM}    cute cat picture
+${SEARCH_TERM}    cute monkey picture
+
 
 *** Keywords ***
 Reject Google Cookies
@@ -16,7 +19,6 @@ Accept Google Consent
 Close Google Sign in if shown
     Click Element If Visible    No thanks
 
-*** Keywords ***
 Open Google search page
     Open Available Browser
     ...    ${GOOGLE_URL}
@@ -26,20 +28,18 @@ Open Google search page
     Reject Google Cookies
     Accept Google Consent
 
-*** Keywords ***
 Search for
     [Arguments]    ${text}
     Input Text    name:q    ${text}
     Press Keys    name:q    ENTER
     Wait Until Page Contains Element    search
 
-*** Keywords ***
 View image search results
     Click Link    Images
 
-*** Keywords ***
 Screenshot first result
     Capture Element Screenshot    css:div[data-ri="0"]
+
 
 *** Tasks ***
 Execute Google image search and store the first result image
@@ -49,7 +49,7 @@ Execute Google image search and store the first result image
         View image search results
         Screenshot first result
     EXCEPT
-        Capture Page Screenshot     %{ROBOT_ARTIFACTS}${/}error.png 
+        Capture Page Screenshot     %{ROBOT_ARTIFACTS}${/}error.png
         Fail    Checkout the screenshot: error.png
     END
     [Teardown]    Close Browser


### PR DESCRIPTION
- Takes into use the latest _conda.yaml_ layout with adequate versions.
- Unpins the `geckodriver` so we let the webdriver-manager do its job given the retrieved Firefox version.
- Fixes the _robot.yaml_ layout and tasks package structure.

----

CR [Process](https://cloud.robocorp.com/orgrobocorp/robocorp/processes/b4ab0452-9add-408f-a3c5-2093fc5e3a65)

Detailed logs before the webdriver starts:
```
10:01:50.200 | DEBUG | Creating webdriver for 'firefox' (headless: True, download: True) |  
-- | -- | -- | --


10:01:50.200	DEBUG	Creating webdriver for 'firefox' (headless: True, download: True)	
10:01:50.200	INFO	====== WebDriver manager ======	
10:02:04.921	DEBUG	Starting new HTTPS connection (1): downloads.robocorp.com:443	
10:02:05.273	DEBUG	[https://downloads.robocorp.com:443](https://downloads.robocorp.com/) "GET /ext/webdrivers/firefox/releases/latest HTTP/1.1" 200 None	
10:02:05.318	DEBUG	Starting new HTTPS connection (1): downloads.robocorp.com:443	
10:02:05.621	DEBUG	[https://downloads.robocorp.com:443](https://downloads.robocorp.com/) "GET /ext/webdrivers/firefox/releases/tags/v0.33.0 HTTP/1.1" 200 None	
10:02:05.634	DEBUG	Starting new HTTPS connection (1): downloads.robocorp.com:443	
10:02:06.166	DEBUG	[https://downloads.robocorp.com:443](https://downloads.robocorp.com/) "GET /ext/webdrivers/firefox/download/v0.33.0/geckodriver-v0.33.0-macos.tar.gz HTTP/1.1" 200 2147841	
10:02:06.342	INFO	Downloaded webdriver to: /Users/cmin/.robocorp/webdrivers/.wdm/drivers/geckodriver/mac64/v0.33.0/geckodriver	
10:02:06.756	INFO	Webdriver version taken into use: geckodriver 0.33.0 (a80e5fd61076 2023-04-02 18:31 +0000)

The source code of this program is available from
testing/geckodriver in https://hg.mozilla.org/mozilla-central.

This program is subject to the terms of the Mozilla Public License 2.0.
You can obtain a copy of the license at https://mozilla.org/MPL/2.0/.
10:02:07.509	INFO	Targeted browser version: 119.0	
10:02:07.509	INFO	Creating an instance of the Firefox WebDriver.	
10:02:07.516	DEBUG	Started executable: `/Users/cmin/.robocorp/webdrivers/.wdm/drivers/geckodriver/mac64/v0.33.0/geckodriver` in a child process with pid: 97723
```

Complete logs without debug info:
[log.html.zip](https://github.com/robocorp/example-google-image-search-firefox/files/13224776/log.html.zip)